### PR TITLE
Fix/minor fix on server startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ build
 
 # Air binary
 hishab
+.vscode/
+!.vscode/settings.json

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -150,6 +150,8 @@ func setupRepositories(databaseConnectionPool *pgxpool.Pool) *repositories.Repos
 }
 
 func run(ctx context.Context, args []string) error {
+	start := time.Now() // Start timing
+
 	ctx, cancel := signal.NotifyContext(ctx, os.Interrupt)
 	defer cancel()
 
@@ -182,10 +184,11 @@ func run(ctx context.Context, args []string) error {
 	}
 	defer databaseConnectionPool.Close()
 
-	// redis initialization
-	success, rdb := cache.Init(log)
-	if !success {
+	// cache initialization
+	rdb, err := cache.Init(log)
+	if err != nil {
 		log.Fatal("failed to initialize redis")
+		return err
 	}
 	defer rdb.Close()
 
@@ -194,6 +197,10 @@ func run(ctx context.Context, args []string) error {
 
 	// repositories initialization
 	repos := setupRepositories(databaseConnectionPool)
+
+	// time taken for prerequisites (logger, db, cache) loading
+	elapsed := time.Since(start)
+	log.Info("server prerequisites (logger, db, cache) loaded successfully", "time", elapsed.String())
 
 	return setupServer(log, ctx, repos)
 }

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -28,11 +28,11 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-func Init(log logger.Logger) (bool, *redis.Client) {
+func Init(log logger.Logger) (*redis.Client, error) {
 	// Load config
 	options, err := loadRedisOptions(log)
 	if err != nil {
-		return false, nil
+		return nil, err
 	}
 
 	// Create client
@@ -45,10 +45,10 @@ func Init(log logger.Logger) (bool, *redis.Client) {
 	pong, err := rdb.Ping(ctx).Result()
 	if err != nil {
 		log.Error("failed to connect to redis", "reason", err)
-		return false, nil
+		return nil, err
 	}
 	log.Info("redis connection successful", "response", pong)
-	return true, rdb
+	return rdb, nil
 }
 
 func loadRedisOptions(log logger.Logger) (*redis.Options, error) {


### PR DESCRIPTION
Wanted to check if its worth implementing go concurrency on server startup. As of now, its not taking a significant time (around `30ms`). So, decided not to spawn routines for database and cache initialization. 

- Performed some minor modifications on error propagation of redis setup. 
- Added log for server prerequisites' (logger, db, cache) loading time
- Added proper gitignore for `.vscode` directory.