### PR TITLE
modified Makefile for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,18 +27,39 @@ help:
 	@echo "  make format              - Format Go code using gofmt"
 	@echo "  make clean               - Remove build artifacts"
 
+# Makefile Util
+
+## Detect OS
+ifeq ($(OS),Windows_NT)
+  DETECTED_OS := Windows
+else
+  DETECTED_OS := $(shell uname -s)
+endif
+
+## Usage: $(call SET_ENV,VAR_NAME,VAR_VALUE)
+define SET_ENV
+  $(if $(filter Windows,$(DETECTED_OS)), \
+    @powershell -Command "$$env:$(1)='$(2)';", \
+    @export $(1)=$(2); \
+  )
+endef
+
 # Development environment
 dev:
-	COMPOSE_BAKE=true docker compose $(DEV_COMPOSE_FILES) up
+	$(call SET_ENV,COMPOSE_BAKE,true)
+	@docker compose $(DEV_COMPOSE_FILES) up
 
 dev-build:
-	COMPOSE_BAKE=true docker compose $(DEV_COMPOSE_FILES) up --build
+	$(call SET_ENV,COMPOSE_BAKE,true)
+	@docker compose $(DEV_COMPOSE_FILES) up --build
 
 dev-detached:
-	COMPOSE_BAKE=true docker compose $(DEV_COMPOSE_FILES) up -d
+	$(call SET_ENV,COMPOSE_BAKE,true)
+	@docker compose $(DEV_COMPOSE_FILES) up -d
 
 dev-build-detached:
-	COMPOSE_BAKE=true docker compose $(DEV_COMPOSE_FILES) up  -d --build
+	$(call SET_ENV,COMPOSE_BAKE,true)
+	@docker compose $(DEV_COMPOSE_FILES) up -d --build
 
 # Production environment
 prod:


### PR DESCRIPTION
```powershell
make dev-build
```

On windows powershell, the above command was showing the following error: 

```powershell
COMPOSE_BAKE=true docker compose -f docker-compose.dev.yaml up --build
'COMPOSE_BAKE' is not recognized as an internal or external command,
operable program or batch file.
make: *** [Makefile:35: dev-build] Error 1
```

So, handled the case. 

- Detect OS
- Set environment variable, specific to that OS